### PR TITLE
Skills system added

### DIFF
--- a/godot/combat/CombatAction.gd
+++ b/godot/combat/CombatAction.gd
@@ -7,6 +7,6 @@ signal execute_finished()
 export var icon : Texture
 export var description : String = "Base combat action"
 
-func execute(actor : Battler, target : Battler):
+func execute(actor : Battler, target : Battler) -> void:
 	print("%s missing overwrite of the execute method" % name)
 	emit_signal("execute_finished")

--- a/godot/combat/CombatArena.gd
+++ b/godot/combat/CombatArena.gd
@@ -40,13 +40,17 @@ func play_turn():
 		battle_end()
 		return
 	var target : Battler
+	var action : CombatAction
 	if battler.party_member:
-		 target = yield(interface.select_target(targets), "completed")
+		interface.update_actions(battler)
+		target = yield(interface.select_target(targets), "completed")
+#		action = get_active_battler().actions.get_child(0)
+		action = interface.selected_action
 	else:
 		# Temp random target selection for the monsters
 		target = battler.choose_target(targets)
+		action = get_active_battler().actions.get_child(0)
 
-	var action : CombatAction = get_active_battler().actions.get_child(0)
 	yield(turn_queue.play_turn(target, action), "completed")
 	
 	battler.selected = false

--- a/godot/combat/CombatArena.tscn
+++ b/godot/combat/CombatArena.tscn
@@ -38,7 +38,6 @@ position = Vector2( 1376, 672 )
 
 [node name="TurnQueue" parent="." instance=ExtResource( 3 )]
 z_index = 10
-_sections_unfolded = [ "Z Index" ]
 
 [node name="Porcupine" parent="TurnQueue" instance=ExtResource( 4 )]
 position = Vector2( 746, 357.096 )
@@ -83,7 +82,6 @@ mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
 theme = ExtResource( 9 )
-_sections_unfolded = [ "Theme" ]
 
 [node name="Row" type="HBoxContainer" parent="CombatInterface/OldSchoolUI"]
 anchor_left = 0.0
@@ -129,7 +127,6 @@ mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
 alignment = 0
-_sections_unfolded = [ "Grow Direction", "Margin" ]
 
 [node name="MonsterWidget" type="HBoxContainer" parent="CombatInterface/OldSchoolUI/Row/MonstersPanel/Column"]
 anchor_left = 0.0
@@ -253,7 +250,6 @@ mouse_default_cursor_shape = 0
 size_flags_horizontal = 3
 size_flags_vertical = 1
 size_flags_stretch_ratio = 2.0
-_sections_unfolded = [ "Size Flags" ]
 
 [node name="Column" type="VBoxContainer" parent="CombatInterface/OldSchoolUI/Row/PartyPanel"]
 anchor_left = 0.0
@@ -269,7 +265,6 @@ mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
 alignment = 0
-_sections_unfolded = [ "Size Flags" ]
 
 [node name="Control" type="Control" parent="CombatInterface/OldSchoolUI/Row/PartyPanel/Column"]
 anchor_left = 0.0
@@ -283,7 +278,6 @@ mouse_filter = 0
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 3
 size_flags_vertical = 1
-_sections_unfolded = [ "Size Flags" ]
 
 [node name="HSeparator" type="HSeparator" parent="CombatInterface/OldSchoolUI/Row/PartyPanel/Column"]
 anchor_left = 0.0
@@ -299,7 +293,43 @@ mouse_filter = 0
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 3
 size_flags_vertical = 1
-_sections_unfolded = [ "Size Flags" ]
+
+[node name="ActionSelector" type="Control" parent="CombatInterface"]
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -171.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+
+[node name="ItemList" type="ItemList" parent="CombatInterface/ActionSelector"]
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -65.0
+margin_top = -70.0
+margin_right = 65.0
+margin_bottom = 70.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = true
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+items = [ "Slash", null, false, "Crush", null, true, "Anihilate", null, false ]
+select_mode = 0
+allow_reselect = false
+icon_mode = 1
+fixed_icon_size = Vector2( 0, 0 )
 
 [node name="LifebarsBuilder" parent="CombatInterface" instance=ExtResource( 10 )]
 
+[connection signal="item_selected" from="CombatInterface/ActionSelector/ItemList" to="CombatInterface" method="_on_ItemList_item_selected"]

--- a/godot/combat/Hit.gd
+++ b/godot/combat/Hit.gd
@@ -7,5 +7,5 @@ class_name Hit
 var damage = 0
 # var effect : StatusEffect = StatusEffect.new()
 
-func _init(strength : int):
-	damage = strength
+func _init(strength : int, additional_damage : int = 0) -> void:
+	damage = strength + additional_damage

--- a/godot/combat/battlers/Battler.gd
+++ b/godot/combat/battlers/Battler.gd
@@ -5,10 +5,11 @@ class_name Battler
 export var TARGET_OFFSET_DISTANCE : float = 120.0
 
 const DEFAULT_CHANCE = 0.75
-onready var stats : CharacterStats = $Job/Stats
+onready var stats : CharacterStats = $Job/Stats as CharacterStats
 onready var lifebar_anchor = $InterfaceAnchor
 onready var skin = $Skin
 onready var actions = $Actions
+onready var skills = $Job/Skills
 
 var target_global_position : Vector2
 
@@ -20,6 +21,8 @@ export var party_member = false
 func _ready() -> void:
 	var direction : Vector2 = Vector2(-1.0, 0.0) if party_member else Vector2(1.0, 0.0)
 	target_global_position = $TargetAnchor.global_position + direction * TARGET_OFFSET_DISTANCE
+	
+	actions.initialize(skills.get_children())
 	
 	stats.connect("health_depleted", self, "_on_health_depleted")
 	self.selectable = true
@@ -39,6 +42,13 @@ func attack(target : Battler):
 	var hit = Hit.new(stats.strength)
 	target.take_damage(hit)
 
+func use_skill(target : Battler, skill : CharacterSkill) -> void:
+	if stats.mana < skill.mana_cost:
+		return
+	stats.mana -= skill.mana_cost
+	var hit = Hit.new(stats.strength, skill.base_damage)
+	target.take_damage(hit)
+
 func take_damage(hit):
 	stats.take_damage(hit)
 	skin.play_stagger()
@@ -54,9 +64,9 @@ func appear():
 	skin.appear()
 
 func choose_target(targets : Array):
-	''' This function will return a target with the following policy:
+	""" This function will return a target with the following policy:
 		There is a chance of DEFAULT_CHANCE to target the foe with min health
-		else it will randomly choose an opponent'''
+		else it will randomly choose an opponent"""
 	var this_chance = randi() % 100
 	var target_min_health = targets[randi() % len(targets)]
 	

--- a/godot/combat/battlers/Battler.tscn
+++ b/godot/combat/battlers/Battler.tscn
@@ -1,13 +1,15 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://combat/battlers/Battler.gd" type="Script" id=1]
 [ext_resource path="res://combat/battlers/BattlerSkin.gd" type="Script" id=2]
 [ext_resource path="res://animation/appear.anim" type="Animation" id=3]
 [ext_resource path="res://combat/battlers/Job.tscn" type="PackedScene" id=4]
 [ext_resource path="res://combat/battlers/jobs/DefaultJob.tres" type="Resource" id=5]
-[ext_resource path="res://combat/battlers/actions/Attack.tscn" type="PackedScene" id=6]
-[ext_resource path="res://combat/battlers/actions/Attack.gd" type="Script" id=7]
-[ext_resource path="res://combat/interface/lifebar/InterfaceAnchor.tscn" type="PackedScene" id=8]
+[ext_resource path="res://combat/battlers/actions/BattlerActions.gd" type="Script" id=6]
+[ext_resource path="res://combat/battlers/actions/SkillAction.tscn" type="PackedScene" id=7]
+[ext_resource path="res://combat/battlers/actions/Attack.tscn" type="PackedScene" id=8]
+[ext_resource path="res://combat/battlers/actions/Attack.gd" type="Script" id=9]
+[ext_resource path="res://combat/interface/lifebar/InterfaceAnchor.tscn" type="PackedScene" id=10]
 
 [sub_resource type="Animation" id=1]
 
@@ -49,16 +51,12 @@ tracks/0/keys = {
 
 [node name="Battler" type="Position2D"]
 script = ExtResource( 1 )
-_sections_unfolded = [ "Visibility" ]
 TARGET_OFFSET_DISTANCE = null
 party_member = false
 
 [node name="Skin" type="Position2D" parent="."]
 modulate = Color( 1, 1, 1, 0 )
 script = ExtResource( 2 )
-_sections_unfolded = [ "Visibility" ]
-TURN_START_MOVE_DISTANCE = null
-TWEEN_DURATION = null
 
 [node name="Tween" type="Tween" parent="Skin"]
 repeat = false
@@ -81,13 +79,16 @@ blend_times = [  ]
 
 [node name="Job" parent="." instance=ExtResource( 4 )]
 starting_stats = ExtResource( 5 )
+starting_skills = null
 
 [node name="Actions" type="Node" parent="."]
+script = ExtResource( 6 )
+skill_action_scene = ExtResource( 7 )
 
-[node name="Attack" parent="Actions" instance=ExtResource( 6 )]
-script = ExtResource( 7 )
+[node name="Attack" parent="Actions" instance=ExtResource( 8 )]
+script = ExtResource( 9 )
 
-[node name="InterfaceAnchor" parent="." instance=ExtResource( 8 )]
+[node name="InterfaceAnchor" parent="." instance=ExtResource( 10 )]
 position = Vector2( 0, 42 )
 
 [node name="TargetAnchor" type="Position2D" parent="."]

--- a/godot/combat/battlers/BlueBattler.tscn
+++ b/godot/combat/battlers/BlueBattler.tscn
@@ -1,15 +1,17 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://combat/battlers/Battler.tscn" type="PackedScene" id=1]
 [ext_resource path="res://animation/BlueAnim.tscn" type="PackedScene" id=2]
 [ext_resource path="res://combat/battlers/jobs/Fighter.tres" type="Resource" id=3]
+[ext_resource path="res://combat/battlers/skills/Slash.tres" type="Resource" id=4]
 
-[node name="Blue" index="0" instance=ExtResource( 1 )]
+[node name="Blue" instance=ExtResource( 1 )]
 
 [node name="BlueAnim" parent="Skin" index="0" instance=ExtResource( 2 )]
 
 [node name="Job" parent="." index="1"]
 starting_stats = ExtResource( 3 )
+starting_skills = [ ExtResource( 4 ) ]
 
 [node name="InterfaceAnchor" parent="." index="3"]
 position = Vector2( 0, 61.8831 )

--- a/godot/combat/battlers/DanBattler.tscn
+++ b/godot/combat/battlers/DanBattler.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://combat/battlers/Battler.tscn" type="PackedScene" id=1]
 [ext_resource path="res://animation/DanAnim.tscn" type="PackedScene" id=2]
 [ext_resource path="res://combat/battlers/jobs/Fighter.tres" type="Resource" id=3]
+[ext_resource path="res://combat/battlers/skills/Slash.tres" type="Resource" id=4]
 
 [sub_resource type="Shader" id=1]
 
@@ -23,6 +24,7 @@ material = SubResource( 2 )
 
 [node name="Job" parent="." index="1"]
 starting_stats = ExtResource( 3 )
+starting_skills = [ ExtResource( 4 ) ]
 
 [node name="InterfaceAnchor" parent="." index="3"]
 position = Vector2( 0, 60.5757 )

--- a/godot/combat/battlers/Job.gd
+++ b/godot/combat/battlers/Job.gd
@@ -3,10 +3,18 @@ extends Node
 
 class_name Job
 
+
 onready var stats = $Stats
 onready var skills = $Skills
 
 export var starting_stats : Resource
+export(Array, String) var starting_skills
+export(PackedScene) var character_skill_scene : PackedScene
 
 func _ready():
 	stats.initialize(starting_stats)
+	if starting_skills != null and starting_skills.size() > 0:
+		for skill in starting_skills:
+			var new_skill = character_skill_scene.instance()
+			new_skill.initialize(skill)
+			skills.add_child(new_skill)

--- a/godot/combat/battlers/Job.tscn
+++ b/godot/combat/battlers/Job.tscn
@@ -1,15 +1,18 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://combat/battlers/Job.gd" type="Script" id=1]
 [ext_resource path="res://combat/battlers/jobs/Fighter.tres" type="Resource" id=2]
-[ext_resource path="res://combat/battlers/stats/Stats.tscn" type="PackedScene" id=3]
+[ext_resource path="res://combat/battlers/skills/CharacterSkill.tscn" type="PackedScene" id=3]
+[ext_resource path="res://combat/battlers/stats/Stats.tscn" type="PackedScene" id=4]
+[ext_resource path="res://combat/battlers/skills/Skills.tscn" type="PackedScene" id=5]
 
 [node name="Job" type="Node"]
 script = ExtResource( 1 )
-_sections_unfolded = [ "skills" ]
 starting_stats = ExtResource( 2 )
+starting_skills = [  ]
+character_skill_scene = ExtResource( 3 )
 
-[node name="Stats" parent="." instance=ExtResource( 3 )]
+[node name="Stats" parent="." instance=ExtResource( 4 )]
 
-[node name="Skills" type="Node" parent="."]
+[node name="Skills" parent="." instance=ExtResource( 5 )]
 

--- a/godot/combat/battlers/actions/Attack.gd
+++ b/godot/combat/battlers/actions/Attack.gd
@@ -1,5 +1,5 @@
 extends CombatAction
 
-func execute(actor : Battler, target : Battler):
+func execute(actor : Battler, target : Battler) -> void:
 	actor.attack(target)
 	emit_signal("execute_finished")

--- a/godot/combat/battlers/actions/BattlerActions.gd
+++ b/godot/combat/battlers/actions/BattlerActions.gd
@@ -1,0 +1,9 @@
+extends Node
+
+export(PackedScene) var skill_action_scene
+
+func initialize(skills : Array) -> void:
+	for skill in skills:
+		var new_skill = skill_action_scene.instance()
+		new_skill.skill_to_use = skill
+		add_child(new_skill)

--- a/godot/combat/battlers/actions/SkillAction.gd
+++ b/godot/combat/battlers/actions/SkillAction.gd
@@ -1,0 +1,16 @@
+extends CombatAction
+
+var skill_to_use : CharacterSkill
+
+func _ready() -> void:
+	name = skill_to_use.name
+	randomize()
+
+func execute(actor : Battler, target : Battler) -> void:
+	if skill_to_use.success_chance == 1.0:
+		actor.use_skill(target, skill_to_use)
+	else:
+		randomize()
+		if rand_range(0, 1.0) < skill_to_use.success_chance:
+			actor.use_skill(target, skill_to_use)
+	emit_signal("execute_finished")

--- a/godot/combat/battlers/actions/SkillAction.tscn
+++ b/godot/combat/battlers/actions/SkillAction.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://combat/battlers/actions/SkillAction.gd" type="Script" id=1]
+
+[node name="SkillAction" type="Node"]
+script = ExtResource( 1 )
+

--- a/godot/combat/battlers/jobs/DefaultJob.tres
+++ b/godot/combat/battlers/jobs/DefaultJob.tres
@@ -7,6 +7,7 @@
 script = ExtResource( 1 )
 job_name = "Job"
 max_health = 6
+max_mana = null
 strength = 2
 defense = 0
 speed = null

--- a/godot/combat/battlers/jobs/Fighter.tres
+++ b/godot/combat/battlers/jobs/Fighter.tres
@@ -7,6 +7,7 @@
 script = ExtResource( 1 )
 job_name = "Fighter"
 max_health = 15
+max_mana = 4
 strength = 4
 defense = 1
 speed = 5

--- a/godot/combat/battlers/jobs/Porcupine.tres
+++ b/godot/combat/battlers/jobs/Porcupine.tres
@@ -7,6 +7,7 @@
 script = ExtResource( 1 )
 job_name = "Porcupine"
 max_health = 6
+max_mana = null
 strength = 3
 defense = 0
 speed = 2

--- a/godot/combat/battlers/jobs/StartingStats.gd
+++ b/godot/combat/battlers/jobs/StartingStats.gd
@@ -5,6 +5,7 @@ class_name StartingStats
 export var job_name : String = "Job"
 
 export var max_health : int
+export var max_mana : int
 export var strength : int
 export var defense : int
 export var speed : int

--- a/godot/combat/battlers/skills/CharacterSkill.gd
+++ b/godot/combat/battlers/skills/CharacterSkill.gd
@@ -1,0 +1,15 @@
+extends Node
+
+class_name CharacterSkill
+
+var skill_description : String
+var mana_cost : int
+var base_damage : int
+var success_chance : float
+
+func initialize(skill : Skill):
+	name = skill.skill_name
+	skill_description = skill.skill_description
+	mana_cost = skill.mana_cost
+	base_damage = skill.base_damage
+	success_chance = skill.success_chance

--- a/godot/combat/battlers/skills/CharacterSkill.tscn
+++ b/godot/combat/battlers/skills/CharacterSkill.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://combat/battlers/skills/CharacterSkill.gd" type="Script" id=1]
+
+[node name="CharacterSkill" type="Node"]
+script = ExtResource( 1 )
+

--- a/godot/combat/battlers/skills/Skill.gd
+++ b/godot/combat/battlers/skills/Skill.gd
@@ -1,0 +1,10 @@
+extends Resource
+
+class_name Skill
+
+export var skill_name : String = "Skill"
+export var skill_description : String = ""
+
+export var mana_cost : int
+export var base_damage : int
+export(float, 0.0, 1.0) var success_chance : float

--- a/godot/combat/battlers/skills/Skills.tscn
+++ b/godot/combat/battlers/skills/Skills.tscn
@@ -1,0 +1,4 @@
+[gd_scene format=2]
+
+[node name="Skills" type="Node"]
+

--- a/godot/combat/battlers/skills/Slash.tres
+++ b/godot/combat/battlers/skills/Slash.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://combat/battlers/skills/Skill.gd" type="Script" id=1]
+
+[resource]
+
+script = ExtResource( 1 )
+skill_name = "Slash"
+skill_description = "Devastating blow with your sword!"
+mana_cost = 4
+base_damage = 2
+success_chance = 1.0
+

--- a/godot/combat/battlers/stats/CharacterStats.gd
+++ b/godot/combat/battlers/stats/CharacterStats.gd
@@ -8,20 +8,27 @@ signal health_depleted()
 var modifiers = {}
 
 var health : int
+var mana : int
 var max_health : int setget set_max_health
+var max_mana : int setget set_max_mana
 var strength : int
 var defense : int
 var speed : int
 
 func initialize(stats : StartingStats):
 	max_health = stats.max_health
+	max_mana = stats.max_mana
 	strength = stats.strength
 	defense = stats.defense
 	speed = stats.speed
 	health = max_health
+	mana = max_mana
 
 func set_max_health(value):
 	max_health = max(0, value)
+
+func set_max_mana(value):
+	max_mana = max(0, value)
 
 func take_damage(hit):
 	health -= hit.damage

--- a/godot/combat/interface/CombatInterface.gd
+++ b/godot/combat/interface/CombatInterface.gd
@@ -2,6 +2,9 @@ extends CanvasLayer
 
 onready var lifebar_builder = $LifebarsBuilder
 onready var select_arrow = $SelectArrow
+onready var action_list = $ActionSelector/ItemList
+
+var selected_action : CombatAction
 
 func initialize(battlers : Array):
 	lifebar_builder.initialize(battlers)
@@ -9,3 +12,16 @@ func initialize(battlers : Array):
 func select_target(selectable_battlers : Array) -> Battler:
 	var selected_target : Battler = yield(select_arrow.select_target(selectable_battlers), "completed")
 	return selected_target
+
+func update_actions(battler : Battler) -> void:
+	action_list.show()
+	action_list.clear()
+	for index in range(battler.actions.get_child_count()):
+		var action = battler.actions.get_children()[index]
+		action_list.add_item(action.name)
+		action_list.set_item_metadata(index, action)
+	action_list.select(0)
+	action_list.emit_signal('item_selected', 0)
+
+func _on_ItemList_item_selected(index):
+	selected_action = action_list.get_item_metadata(index) as CombatAction


### PR DESCRIPTION
It's now possible to add skills as resources and use them in combat.
Some changes:

- Initial stats now have mana
- A combat action for skills has been added
- A really simple menu to select which action to perform in the given
turn
- Resource for skills
- Skills can be executed on a given chance

What can be improved:
- As of now, the skills have a `base_damage` which is added on top of the
already calculated damage in the `Hit` script. We might want to use the
strength as a multiplier to increase the overall damage of the skill,
for instance, instead of just adding them together.

- The menu for selecting the action is really simple and the UX is bad
to say the least. I'll create a separate issue for this.

- Skills are only available as a form of attack, i.e. you can't create
healing skill with the current system. But it can be extended to do so.

- They are not specific to jobs. For instance, both Dan and Blue are
fighters, but you'll have to add skills to them separately. Though, this
is most due to how they were created. We should probably create a
separate FighterJob and add the skills to them, this would fix the
problem imo.

Closes #16 and #15