### PR TITLE
Add dialogue system to LocalMap

### DIFF
--- a/godot/dialogue/Dialogue.gd
+++ b/godot/dialogue/Dialogue.gd
@@ -1,0 +1,19 @@
+extends Node
+
+export (String, FILE, "*.json") var dialogue_file : String
+
+func load_dialogue() -> Dictionary:
+	"""
+	Parse a JSON file and returns it or an empty dictionary if the
+	file doesn't exist.
+	"""
+	
+	var file = File.new()
+	
+	if file.file_exists(dialogue_file):
+		file.open(dialogue_file, file.READ)
+		
+		var dialogue = parse_json(file.get_as_text())
+		
+		return dialogue
+	return {}

--- a/godot/dialogue/Dialogue.gd
+++ b/godot/dialogue/Dialogue.gd
@@ -1,8 +1,8 @@
 extends Node
 
-export (String, FILE, "*.json") var dialogue_file : String
+export (String, FILE, "*.json") var file_path : String
 
-func load_dialogue() -> Dictionary:
+func load() -> Dictionary:
 	"""
 	Parse a JSON file and returns it or an empty dictionary if the
 	file doesn't exist.
@@ -10,10 +10,9 @@ func load_dialogue() -> Dictionary:
 	
 	var file = File.new()
 	
-	if file.file_exists(dialogue_file):
-		file.open(dialogue_file, file.READ)
-		
+	if file.file_exists(file_path):
+		file.open(file_path, file.READ)
 		var dialogue = parse_json(file.get_as_text())
-		
 		return dialogue
+	
 	return {}

--- a/godot/dialogue/Dialogue.tscn
+++ b/godot/dialogue/Dialogue.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://dialogue/Dialogue.gd" type="Script" id=1]
+
+[node name="Dialogue" type="Node"]
+script = ExtResource( 1 )
+dialogue_file = ""
+

--- a/godot/dialogue/dialogue_data/object.json
+++ b/godot/dialogue/dialogue_data/object.json
@@ -1,0 +1,3 @@
+{
+  "dialog_1" : {"name":"", "text":"YOU PICKED UP AN OBJECT!!" }
+}

--- a/godot/dialogue/dialogue_player/DialoguePlayer.gd
+++ b/godot/dialogue/dialogue_player/DialoguePlayer.gd
@@ -10,10 +10,10 @@ var dialogue_text : String = ""
 signal started
 signal finished
 
-func start_dialogue(dialogue):
+func start(dialogue):
 	emit_signal("started")
 	index = 0
-	index_dialogue(dialogue)
+	to_index(dialogue)
 	
 	dialogue_text = dialogue_keys[index].text
 	dialogue_name = dialogue_keys[index].name
@@ -21,7 +21,7 @@ func start_dialogue(dialogue):
 	if is_finished():
 		emit_signal("finished")
 
-func next_dialogue():
+func next():
 	index += 1
 	
 	if is_finished():
@@ -31,7 +31,7 @@ func next_dialogue():
 	dialogue_text = dialogue_keys[index].text
 	dialogue_name = dialogue_keys[index].name
 
-func index_dialogue(dialogue):
+func to_index(dialogue):
 	dialogue_keys.clear()
 	
 	for key in dialogue:

--- a/godot/dialogue/dialogue_player/DialoguePlayer.gd
+++ b/godot/dialogue/dialogue_player/DialoguePlayer.gd
@@ -1,0 +1,41 @@
+extends Node
+
+class_name DialoguePlayer
+
+var dialogue_keys : Array = []
+var dialogue_name : String = ""
+var index : int = 0
+var dialogue_text : String = ""
+
+signal dialogue_started
+signal dialogue_finished
+
+func start_dialogue(dialogue):
+	emit_signal("dialogue_started")
+	index = 0
+	index_dialogue(dialogue)
+	
+	dialogue_text = dialogue_keys[index].text
+	dialogue_name = dialogue_keys[index].name
+	
+	if is_finished():
+		emit_signal("dialogue_finished")
+
+func next_dialogue():
+	index += 1
+	
+	if is_finished():
+		emit_signal("dialogue_finished")
+		return
+	
+	dialogue_text = dialogue_keys[index].text
+	dialogue_name = dialogue_keys[index].name
+
+func index_dialogue(dialogue):
+	dialogue_keys.clear()
+	
+	for key in dialogue:
+		dialogue_keys.append(dialogue[key])
+
+func is_finished() -> bool:
+	return index >= dialogue_keys.size() -1

--- a/godot/dialogue/dialogue_player/DialoguePlayer.gd
+++ b/godot/dialogue/dialogue_player/DialoguePlayer.gd
@@ -7,11 +7,11 @@ var dialogue_name : String = ""
 var index : int = 0
 var dialogue_text : String = ""
 
-signal dialogue_started
-signal dialogue_finished
+signal started
+signal finished
 
 func start_dialogue(dialogue):
-	emit_signal("dialogue_started")
+	emit_signal("started")
 	index = 0
 	index_dialogue(dialogue)
 	
@@ -19,13 +19,13 @@ func start_dialogue(dialogue):
 	dialogue_name = dialogue_keys[index].name
 	
 	if is_finished():
-		emit_signal("dialogue_finished")
+		emit_signal("finished")
 
 func next_dialogue():
 	index += 1
 	
 	if is_finished():
-		emit_signal("dialogue_finished")
+		emit_signal("finished")
 		return
 	
 	dialogue_text = dialogue_keys[index].text

--- a/godot/dialogue/dialogue_player/DialoguePlayer.tscn
+++ b/godot/dialogue/dialogue_player/DialoguePlayer.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://dialogue/dialogue_player/DialoguePlayer.gd" type="Script" id=1]
+
+[node name="DialoguePlayer" type="Node"]
+script = ExtResource( 1 )
+

--- a/godot/local_map/DialogueBox.gd
+++ b/godot/local_map/DialogueBox.gd
@@ -13,7 +13,7 @@ func initialize(dialogue):
 	next_button.grab_focus()
 	next_button.text = "Next"
 	
-	dialogue_player.start_dialogue(dialogue)
+	dialogue_player.start(dialogue)
 	
 	update_content()
 	show()
@@ -26,7 +26,7 @@ func _on_dialogue_player_finished():
 	hide()
 
 func _on_next_button_down():
-	dialogue_player.next_dialogue()
+	dialogue_player.next()
 	update_content()
 	
 func update_content() -> void:

--- a/godot/local_map/DialogueBox.gd
+++ b/godot/local_map/DialogueBox.gd
@@ -1,0 +1,34 @@
+extends Control
+
+onready var dialogue_player : DialoguePlayer = get_node("DialoguePlayer")
+onready var name_label : Label = get_node("Panel/Colums/Name")
+onready var text_label : Label = get_node("Panel/Colums/Text")
+onready var next_button : Button = get_node("Panel/Colums/Next")
+
+func _ready():
+	next_button.connect("button_down", self, "_on_next_button_down")
+	dialogue_player.connect("dialogue_finished", self, "_on_dialogue_player_finished")
+	
+func _on_LocalMap_dialogue_started(dialogue):
+	next_button.grab_focus()
+	next_button.text = "Next"
+	
+	dialogue_player.start_dialogue(dialogue)
+	
+	set_dialogue()
+	show()
+
+func _on_dialogue_player_finished():
+	next_button.text = "Finished"
+	
+	yield(next_button, "button_down")
+	
+	hide()
+
+func _on_next_button_down():
+	dialogue_player.next_dialogue()
+	set_dialogue()
+	
+func set_dialogue() -> void:
+	name_label.text = dialogue_player.dialogue_name
+	text_label.text = dialogue_player.dialogue_text

--- a/godot/local_map/DialogueBox.gd
+++ b/godot/local_map/DialogueBox.gd
@@ -7,15 +7,15 @@ onready var next_button : Button = get_node("Panel/Colums/Next")
 
 func _ready():
 	next_button.connect("button_down", self, "_on_next_button_down")
-	dialogue_player.connect("dialogue_finished", self, "_on_dialogue_player_finished")
+	dialogue_player.connect("finished", self, "_on_dialogue_player_finished")
 	
-func _on_LocalMap_dialogue_started(dialogue):
+func initialize(dialogue):
 	next_button.grab_focus()
 	next_button.text = "Next"
 	
 	dialogue_player.start_dialogue(dialogue)
 	
-	set_dialogue()
+	update_content()
 	show()
 
 func _on_dialogue_player_finished():
@@ -27,8 +27,8 @@ func _on_dialogue_player_finished():
 
 func _on_next_button_down():
 	dialogue_player.next_dialogue()
-	set_dialogue()
+	update_content()
 	
-func set_dialogue() -> void:
+func update_content() -> void:
 	name_label.text = dialogue_player.dialogue_name
 	text_label.text = dialogue_player.dialogue_text

--- a/godot/local_map/LocalMap.gd
+++ b/godot/local_map/LocalMap.gd
@@ -1,3 +1,8 @@
 extends Node
 
 signal encounter(enemy_group)
+
+signal dialogue(dialogue)
+
+func _ready():
+	connect("dialogue", $MapInterface/Dialogue, "_on_LocalMap_dialogue_started")

--- a/godot/local_map/LocalMap.gd
+++ b/godot/local_map/LocalMap.gd
@@ -5,4 +5,4 @@ signal encounter(enemy_group)
 signal dialogue(dialogue)
 
 func _ready():
-	connect("dialogue", $MapInterface/Dialogue, "_on_LocalMap_dialogue_started")
+	connect("dialogue", $MapInterface/Dialogue, "initialize")

--- a/godot/local_map/LocalMap.tscn
+++ b/godot/local_map/LocalMap.tscn
@@ -106,7 +106,7 @@ formation = ExtResource( 7 )
 texture = ExtResource( 9 )
 
 [node name="Dialogue" parent="Grid/Object" instance=ExtResource( 10 )]
-dialogue_file = "res://dialogue/dialogue_data/object.json"
+file_path = "res://dialogue/dialogue_data/object.json"
 
 [node name="MapInterface" type="CanvasLayer" parent="."]
 pause_mode = 2

--- a/godot/local_map/LocalMap.tscn
+++ b/godot/local_map/LocalMap.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://local_map/LocalMap.gd" type="Script" id=1]
 [ext_resource path="res://local_map/tilesets/grid_lines/grid_lines_tileset.tres" type="TileSet" id=2]
@@ -9,6 +9,9 @@
 [ext_resource path="res://combat/battlers/formations/PorcupineFormation001.tscn" type="PackedScene" id=7]
 [ext_resource path="res://local_map/pawns/sprites/character_grey.png" type="Texture" id=8]
 [ext_resource path="res://local_map/pawns/sprites/star.png" type="Texture" id=9]
+[ext_resource path="res://dialogue/Dialogue.tscn" type="PackedScene" id=10]
+[ext_resource path="res://local_map/DialogueBox.gd" type="Script" id=11]
+[ext_resource path="res://dialogue/dialogue_player/DialoguePlayer.tscn" type="PackedScene" id=12]
 
 [node name="LocalMap" type="Node2D"]
 script = ExtResource( 1 )
@@ -96,11 +99,131 @@ texture = ExtResource( 8 )
 [node name="Object" type="Node2D" parent="Grid"]
 position = Vector2( 544, 288 )
 script = ExtResource( 6 )
-type = 0
+type = 2
 formation = ExtResource( 7 )
 
 [node name="Sprite" type="Sprite" parent="Grid/Object"]
 texture = ExtResource( 9 )
+
+[node name="Dialogue" parent="Grid/Object" instance=ExtResource( 10 )]
+dialogue_file = "res://dialogue/dialogue_data/object.json"
+
+[node name="MapInterface" type="CanvasLayer" parent="."]
+pause_mode = 2
+layer = 1
+offset = Vector2( 0, 0 )
+rotation = 0.0
+scale = Vector2( 1, 1 )
+transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+
+[node name="Dialogue" type="Control" parent="MapInterface"]
+visible = false
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+script = ExtResource( 11 )
+
+[node name="Panel" type="Panel" parent="MapInterface/Dialogue"]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -280.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+
+[node name="Colums" type="HBoxContainer" parent="MapInterface/Dialogue/Panel"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 20.0
+margin_top = 20.0
+margin_right = 1900.0
+margin_bottom = 260.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+alignment = 0
+
+[node name="Name" type="Label" parent="MapInterface/Dialogue/Panel/Colums"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 38.0
+margin_bottom = 240.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 5
+text = "Name"
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
+[node name="Text" type="Label" parent="MapInterface/Dialogue/Panel/Colums"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 42.0
+margin_right = 1696.0
+margin_bottom = 240.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 3
+size_flags_vertical = 5
+text = "Dialogue Text"
+align = 1
+valign = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
+[node name="Next" type="Button" parent="MapInterface/Dialogue/Panel/Colums"]
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 1700.0
+margin_right = 1880.0
+margin_bottom = 80.0
+rect_min_size = Vector2( 180, 80 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 0
+toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
+text = "Next"
+flat = false
+align = 1
+
+[node name="DialoguePlayer" parent="MapInterface/Dialogue" instance=ExtResource( 12 )]
 
 
 [editable path="Grid/Actor"]

--- a/godot/local_map/grid/grid.gd
+++ b/godot/local_map/grid/grid.gd
@@ -24,6 +24,11 @@ func request_move(pawn, direction):
 			return update_pawn_position(pawn, cell_start, cell_target)
 		CELL_TYPES.OBJECT:
 			var object_pawn = get_cell_pawn(cell_target)
+			
+			if object_pawn.has_node("Dialogue"):
+				var dialogue : Dictionary = object_pawn.get_node("Dialogue").load_dialogue()
+				get_parent().emit_signal("dialogue", dialogue)
+				
 			object_pawn.queue_free()
 			return update_pawn_position(pawn, cell_start, cell_target)
 		CELL_TYPES.ACTOR:

--- a/godot/local_map/grid/grid.gd
+++ b/godot/local_map/grid/grid.gd
@@ -24,9 +24,9 @@ func request_move(pawn, direction):
 			return update_pawn_position(pawn, cell_start, cell_target)
 		CELL_TYPES.OBJECT:
 			var object_pawn = get_cell_pawn(cell_target)
-			
+		
 			if object_pawn.has_node("Dialogue"):
-				var dialogue : Dictionary = object_pawn.get_node("Dialogue").load_dialogue()
+				var dialogue = object_pawn.get_node("Dialogue").load()
 				get_parent().emit_signal("dialogue", dialogue)
 				
 			object_pawn.queue_free()


### PR DESCRIPTION
With this I think we close #22 I didn't create a NPC, need feedback on the implementation first, so what I did was just create a basic dialogue that appears when you pick an item.

I made some changes to what we have in the RPG demo in Godot, there we have a DialoguePlayer for each think that could potentially start a Dialogue, now we have Dialogues, which parse JSON files into Dictionaries when Dialogue.load_dialogue() and they have the path to the JSON file.

Now the DialoguePlayer is a node responsible only for keep and communicate the flow of the Dialogue, if it started, ended, what is the current data (name, text) etc...

With this we instead of having to grab DialoguePlayer nodes around the memory, we just keep track of the Dictionary.

I did this because the Object was getting free and we lost reference to its DialoguePlayer, with this current approach it just passes the data we need and can be free, no worries.