### PR TITLE
Added the ability to cancel the selection arrow

### DIFF
--- a/godot/combat/CombatAction.gd
+++ b/godot/combat/CombatAction.gd
@@ -23,9 +23,10 @@ func initialize(p_targets : Array, p_allys : Array, p_actor : Battler) -> void:
 	actor = p_actor
 	initialized = true
 
-func execute() -> void:
+func execute():
 	assert(initialized)
 	print("%s missing overwrite of the execute method" % name)
+	return false
 
 func attack_routine():
 	actor.attack(target)
@@ -41,6 +42,7 @@ func select_target_routine():
 	var interface = actor.get_tree().get_nodes_in_group("interface")[0]
 	target = yield(interface.select_target(targets), "completed")
 	interface.action_list.hide()
+	return target
 
 func use_skill_routine():
 	if skill_to_use.success_chance == 1.0:
@@ -51,4 +53,3 @@ func use_skill_routine():
 			actor.use_skill(target, skill_to_use)
 	yield(actor.get_tree().create_timer(1.0), "timeout")
 	
-

--- a/godot/combat/CombatArena.gd
+++ b/godot/combat/CombatArena.gd
@@ -109,7 +109,6 @@ func play_turn():
 			# Temp random target selection for the monsters
 			action = get_active_battler().actions.get_child(0)
 			action.target = battler.choose_target(targets)
-		
 		yield(turn_queue.play_turn(action), "completed")
 		battler.selected = false
 	else:

--- a/godot/combat/battlers/actions/Attack.gd
+++ b/godot/combat/battlers/actions/Attack.gd
@@ -5,7 +5,10 @@ func execute():
 	print("TODO: ATTACK -> at some point we should define the attack commands based on the equiped items\n" +
 		  "ie: if you have a bow you should not move to the target!")
 	if actor.party_member:
-		yield(select_target_routine(), "completed")
+		var target = yield(select_target_routine(), "completed")
+		if target == null:
+			return false
 	yield(move_to_target_routine(), "completed")
 	yield(attack_routine(), "completed")
 	yield(return_to_start_position_routine(), "completed")
+	return true

--- a/godot/combat/battlers/actions/SkillAction.gd
+++ b/godot/combat/battlers/actions/SkillAction.gd
@@ -8,7 +8,10 @@ func execute():
 	assert(initialized)
 	if actor.party_member:
 		print("TODO: SKILL -> if skill can target all enemies this command should be changed to SelectAllCommand")
-		yield(select_target_routine(), "completed")
+		var target = yield(select_target_routine(), "completed")
+		if target == null:
+			return false
 	yield(move_to_target_routine(), "completed")
 	yield(use_skill_routine(), "completed")
 	yield(return_to_start_position_routine(), "completed")
+	return true

--- a/godot/combat/interface/SelectArrow.gd
+++ b/godot/combat/interface/SelectArrow.gd
@@ -43,6 +43,9 @@ func _gui_input(event):
 	if event.is_action_pressed("ui_accept"):
 		emit_signal("target_selected", target_active)
 		get_tree().set_input_as_handled()
+	elif event.is_action_pressed("ui_cancel"):
+		emit_signal("target_selected", null)
+		get_tree().set_input_as_handled()
 	
 	var index = targets.find(target_active)
 	if event.is_action_pressed("ui_down"):

--- a/godot/combat/turn_queue/TurnQueue.gd
+++ b/godot/combat/turn_queue/TurnQueue.gd
@@ -3,6 +3,7 @@ extends YSort
 class_name TurnQueue
 
 onready var active_battler : Battler
+var last_action_canceled : bool = false
 
 func initialize():
 	var battlers = get_battlers()
@@ -12,13 +13,17 @@ func initialize():
 	active_battler = get_child(0)
 
 func play_turn(action : CombatAction):
-	yield(active_battler.skin.move_forward(), "completed")
+	if not last_action_canceled:
+		yield(active_battler.skin.move_forward(), "completed")
 	if active_battler.party_member:
 		action.initialize(get_monsters(), get_party(), active_battler)
 	else:
 		action.initialize(get_party(), get_monsters(), active_battler)
-	yield(action.execute(), "completed")
-	
+	var hit_target = yield(action.execute(), "completed")
+	if not hit_target:
+		last_action_canceled = true
+		return
+	last_action_canceled = false
 	var new_index : int = (active_battler.get_index() + 1) % get_child_count()
 	active_battler = get_child(new_index)
 


### PR DESCRIPTION
Had to remove the typed part of the `execute()` function from CombatAction.gd. It wasn't a `void` anymore: it returns if it actually managed to hit a target. When changing the function type to bool, yields would throw an error. I'm not sure if this is a bug with typed GDScript or what.

Closes #54 