### PR TITLE
Characters dialogue database and portraits added

### DIFF
--- a/godot/dialogue/DialogueDatabase.gd
+++ b/godot/dialogue/DialogueDatabase.gd
@@ -1,0 +1,14 @@
+extends Node
+
+const DIALOGUE_CHARACTERS = {
+	"Godette": "res://dialogue/characters/GodetteDialogue.tres",
+	"Robi": "res://dialogue/characters/RobiDialogue.tres",
+}
+
+func get_texture(character_name : String, expression : String) -> Texture:
+	"""
+	Gets the texture with the desired expression from a given character
+	@return Texture with desired expression
+	"""
+	var resource = load(DIALOGUE_CHARACTERS[character_name])
+	return resource.expression_textures[expression]

--- a/godot/dialogue/DialoguePlayer.gd
+++ b/godot/dialogue/DialoguePlayer.gd
@@ -7,6 +7,7 @@ signal finished
 
 var title : String = ""
 var text : String = ""
+var expression : String
 
 var _conversation : Array
 var _index_current : int = 0
@@ -29,5 +30,6 @@ func next():
 func _update():
 	text = _conversation[_index_current].text
 	title = _conversation[_index_current].name
+	expression = _conversation[_index_current].expression
 	if _index_current == _conversation.size() - 1:
 		emit_signal("finished")

--- a/godot/dialogue/characters/DialogueCharacter.gd
+++ b/godot/dialogue/characters/DialogueCharacter.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name DialogueCharacter
+
+export var display_name : String
+export var character_background : String
+export var expression_textures : Dictionary

--- a/godot/dialogue/characters/GodetteDialogue.tres
+++ b/godot/dialogue/characters/GodetteDialogue.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" load_steps=3 format=2]
+
+[ext_resource path="res://assets/sprites/battlers/godette.png" type="Texture" id=1]
+[ext_resource path="res://dialogue/characters/DialogueCharacter.gd" type="Script" id=2]
+
+[resource]
+
+script = ExtResource( 2 )
+display_name = "Godette"
+character_background = "Not much is known about her"
+expression_textures = {
+"normal": ExtResource( 1 )
+}
+

--- a/godot/dialogue/characters/RobiDialogue.tres
+++ b/godot/dialogue/characters/RobiDialogue.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" load_steps=3 format=2]
+
+[ext_resource path="res://assets/sprites/battlers/robi.png" type="Texture" id=1]
+[ext_resource path="res://dialogue/characters/DialogueCharacter.gd" type="Script" id=2]
+
+[resource]
+
+script = ExtResource( 2 )
+display_name = "Robi"
+character_background = "Bingo bango bongo bish bash bosh"
+expression_textures = {
+"happy": ExtResource( 1 )
+}
+

--- a/godot/dialogue/data/test_conversation.json
+++ b/godot/dialogue/data/test_conversation.json
@@ -1,4 +1,4 @@
 {
-    "001" : {"name":"", "text":"You found something." },
-    "002" : {"name":"", "text":"I don't know what that is, but at least it's something!" }
+    "001" : {"name":"Godette", "expression": "normal", "text":"You found something." },
+    "002" : {"name":"Robi", "expression": "happy", "text":"I don't know what that is, but at least it's something!" }
 }

--- a/godot/interface/gui/DialogueBox.tscn
+++ b/godot/interface/gui/DialogueBox.tscn
@@ -18,6 +18,23 @@ size_flags_vertical = 1
 theme = ExtResource( 1 )
 script = ExtResource( 2 )
 
+[node name="Portrait" type="TextureRect" parent="."]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -364.0
+margin_top = -601.0
+margin_right = -113.0
+margin_bottom = -258.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+stretch_mode = 0
+
 [node name="Panel" type="Panel" parent="."]
 anchor_left = 0.0
 anchor_top = 1.0

--- a/godot/local_map/DialogueBox.gd
+++ b/godot/local_map/DialogueBox.gd
@@ -2,11 +2,13 @@ extends Control
 
 onready var dialogue_player : DialoguePlayer = get_node("DialoguePlayer")
 
-onready var name_label : Label = get_node("Panel/Colums/Name")
-onready var text_label : Label = get_node("Panel/Colums/Text")
+onready var name_label : = get_node("Panel/Colums/Name") as Label
+onready var text_label : = get_node("Panel/Colums/Text") as Label
 
-onready var button_next : Button = get_node("Panel/Colums/ButtonNext")
-onready var button_finished : Button = get_node("Panel/Colums/ButtonFinished")
+onready var button_next : = get_node("Panel/Colums/ButtonNext") as Button
+onready var button_finished : = get_node("Panel/Colums/ButtonFinished") as Button
+
+onready var portrait : = $Portrait as TextureRect
 
 func initialize(dialogue):
 	button_next.grab_focus()
@@ -28,5 +30,7 @@ func _on_ButtonFinished_pressed() -> void:
 	hide()
 
 func update_content() -> void:
-	name_label.text = dialogue_player.title
+	var dialogue_player_name = dialogue_player.title
+	name_label.text = dialogue_player_name
 	text_label.text = dialogue_player.text
+	portrait.texture = DialogueDatabase.get_texture(dialogue_player_name, dialogue_player.expression)

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -39,6 +39,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://items/ConsumableItem.gd"
 }, {
+"base": "Resource",
+"class": "DialogueCharacter",
+"language": "GDScript",
+"path": "res://dialogue/characters/DialogueCharacter.gd"
+}, {
 "base": "Node",
 "class": "DialoguePlayer",
 "language": "GDScript",
@@ -141,6 +146,7 @@ _global_script_class_icons={
 "CharacterStats": "",
 "CombatAction": "",
 "ConsumableItem": "",
+"DialogueCharacter": "",
 "DialoguePlayer": "",
 "Equipment": "",
 "Formation": "",
@@ -168,6 +174,10 @@ config/name="Godot Open RPG"
 run/main_scene="res://Game.tscn"
 config/icon="res://icon.png"
 config/version="0.2.0"
+
+[autoload]
+
+DialogueDatabase="*res://dialogue/DialogueDatabase.gd"
 
 [display]
 


### PR DESCRIPTION
I opted to serve the textures with a function in the database that handles the fetching of the desired texture. It looked more natural and less error-prone than to add this logic to the Dialogue.gd since all it does is returning the Dictionary with the dialogue phrases, the actual building of the interface happens in DialogueBox. There, I fetch the textures by reaching to the database. 

Closes #92