### PR TITLE
Small tweaks on Grid and LocalMap

### DIFF
--- a/godot/local_map/LocalMap.tscn
+++ b/godot/local_map/LocalMap.tscn
@@ -63,7 +63,6 @@ script = ExtResource( 4 )
 __meta__ = {
 "_edit_lock_": true
 }
-map_size = Vector2( 16, 16 )
 
 [node name="SpawningPoint" parent="Grid" instance=ExtResource( 5 )]
 position = Vector2( 544, 544 )

--- a/godot/local_map/grid/GameBoard.gd
+++ b/godot/local_map/grid/GameBoard.gd
@@ -8,7 +8,7 @@ class_name GameBoard
 
 enum CELL_TYPES { EMPTY = -1, ACTOR, OBSTACLE, OBJECT }
 
-var pathfinder : Pathfinder = preload("res://local_map/grid/Pathfinder.gd").new()
+var pathfinder : Pathfinder = Pathfinder.new()
 onready var pawns : YSort = $Pawns
 onready var spawning_point = $SpawningPoint
 


### PR DESCRIPTION
Delete reference to map_size in localmap.tscn
instantiate class pathfinder directly with the class_name instead that preload gd file