### PR TITLE
Create extensible AI for battlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New
 
+#### Battle system
+
+- Added support for extensible AI on battlers, allowing the ability to craft custom AI on a per enemy type/character basis.
+
 #### Map
 
 - Leader and followers now reflect the player's party

--- a/godot/combat/CombatArena.gd
+++ b/godot/combat/CombatArena.gd
@@ -74,6 +74,8 @@ func ready_field(formation : Formation, party_members : Array):
 		spawn_point.replace_by(platform)
 		turn_queue.add_child(combatant)
 		self.party.append(combatant)
+		# safely attach the interface to the AI in case player input is needed
+		combatant.ai.set("interface", interface)
 
 func battle_end():
 	active = false
@@ -101,15 +103,8 @@ func play_turn():
 		battle_end()
 		return
 
-	if battler.party_member:
-		interface.open_actions_menu(battler)
-		action = yield(interface, "action_selected")
-		interface.select_targets(opponents)
-		targets = yield(interface, "targets_selected")
-	else:
-		# Temp random target selection for the monsters
-		action = get_active_battler().actions.get_child(0)
-		targets = battler.choose_target(opponents)
+	action = yield(battler.ai.choose_action(battler, opponents), "completed")
+	targets = yield(battler.ai.choose_target(battler, action, opponents), "completed")
 	battler.selected = false
 	
 	if targets != []:

--- a/godot/combat/battlers/Battler.gd
+++ b/godot/combat/battlers/Battler.gd
@@ -4,13 +4,13 @@ class_name Battler
 
 export var TARGET_OFFSET_DISTANCE : float = 120.0
 
-const DEFAULT_CHANCE = 0.75
 export var stats : Resource
 var drops : Array
 onready var skin = $Skin
 onready var actions = $Actions
 onready var bars = $Bars
 onready var skills = $Skills
+onready var ai = $AI
 
 var target_global_position : Vector2
 
@@ -55,22 +55,3 @@ func appear():
 
 func has_point(point : Vector2):
 	return skin.battler_anim.extents.has_point(point)
-
-# TODO: Move to AI-specific file
-func choose_target(targets : Array) -> Array:
-	"""
-	This function will return a target with the following policy:
-	else it will randomly choose an opponent
-	Returns the target wrapped in an Array
-	"""
-	var this_chance = randi() % 100
-	var target_min_health = targets[randi() % len(targets)]
-	
-	if this_chance > DEFAULT_CHANCE:
-		return [target_min_health]
-	
-	var min_health = target_min_health.stats.health 
-	for target in targets:
-		if target.stats.health < min_health:
-			target_min_health = target
-	return [target_min_health]

--- a/godot/combat/battlers/Battler.tscn
+++ b/godot/combat/battlers/Battler.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://combat/battlers/Battler.gd" type="Script" id=1]
 [ext_resource path="res://combat/battlers/BattlerSkin.gd" type="Script" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://combat/battlers/actions/Attack.tscn" type="PackedScene" id=5]
 [ext_resource path="res://combat/battlers/actions/Attack.gd" type="Script" id=6]
 [ext_resource path="res://combat/battlers/skills/Skills.tscn" type="PackedScene" id=7]
+[ext_resource path="res://combat/battlers/ai/BattlerAI.gd" type="Script" id=8]
 
 [sub_resource type="Animation" id=1]
 
@@ -106,5 +107,7 @@ alignment = 0
 [node name="Skills" parent="." instance=ExtResource( 7 )]
 
 [node name="Drops" type="YSort" parent="."]
-sort_enabled = true
+
+[node name="AI" type="Node" parent="."]
+script = ExtResource( 8 )
 

--- a/godot/combat/battlers/ai/BattlerAI.gd
+++ b/godot/combat/battlers/ai/BattlerAI.gd
@@ -1,0 +1,17 @@
+extends Node
+
+class_name BattlerAI
+
+func choose_action(actor : Battler, battlers : Array = []):
+	"""
+	Select an action to perform in combat
+	Can be based on state of the actor
+	"""
+	pass
+	
+func choose_target(actor : Battler, action : CombatAction, battlers : Array = []):
+	"""
+	Chooses a target to perform an action on
+	"""
+	pass
+	

--- a/godot/combat/battlers/ai/PlayerInput.gd
+++ b/godot/combat/battlers/ai/PlayerInput.gd
@@ -1,0 +1,18 @@
+extends BattlerAI
+
+var interface : Node
+
+func choose_action(actor : Battler, battlers : Array = []):
+	"""
+	Select an action to perform in combat
+	Can be based on state of the actor
+	"""
+	interface.open_actions_menu(actor)
+	return yield(interface, "action_selected")
+	
+func choose_target(actor : Battler, action : CombatAction, battlers : Array = []):
+	"""
+	Chooses a target to perform an action on
+	"""
+	interface.select_targets(battlers)
+	return yield(interface, "targets_selected")

--- a/godot/combat/battlers/ai/RandomAI.gd
+++ b/godot/combat/battlers/ai/RandomAI.gd
@@ -1,0 +1,34 @@
+extends BattlerAI
+
+const DEFAULT_CHANCE = 0.75
+
+func choose_action(actor : Battler, battlers : Array = []):
+	"""
+	For now, we just choose the first action on a battler
+	"""
+	# we use yield even though determining an action is instantaneous
+	# because the combat arena expects this to be an async function
+	yield(get_tree(), "idle_frame")
+	return actor.actions.get_child(0)
+	
+func choose_target(actor : Battler, action : CombatAction, battlers : Array = []):
+	"""
+	Chooses a target to perform an action on
+	"""
+	yield(get_tree(), "idle_frame")
+	var this_chance = randi() % 100
+	var target_min_health = battlers[randi() % len(battlers)]
+	
+	if this_chance > DEFAULT_CHANCE:
+		return [target_min_health]
+	
+	var min_health = target_min_health.stats.health 
+	for target in battlers:
+		# don't attack battlers on your team
+		if actor.party_member == target.party_member:
+			continue
+
+		if target.stats.health < min_health:
+			target_min_health = target
+		
+	return [target_min_health]

--- a/godot/combat/battlers/enemies/porcupine/PorcupineBattler.tscn
+++ b/godot/combat/battlers/enemies/porcupine/PorcupineBattler.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://combat/battlers/Battler.tscn" type="PackedScene" id=1]
 [ext_resource path="res://combat/battlers/enemies/porcupine/Porcupine.tres" type="Resource" id=2]
 [ext_resource path="res://animation/PorcupineAnim.tscn" type="PackedScene" id=3]
+[ext_resource path="res://combat/battlers/ai/RandomAI.gd" type="Script" id=4]
 
-[node name="Porcupine" index="0" instance=ExtResource( 1 )]
+[node name="Porcupine" instance=ExtResource( 1 )]
 stats = ExtResource( 2 )
 
 [node name="PorcupineAnim" parent="Skin" index="2" instance=ExtResource( 3 )]
+
+[node name="AI" parent="." index="6"]
+script = ExtResource( 4 )
 

--- a/godot/combat/battlers/enemies/porcupine/StrongerPorcupineBattler.tscn
+++ b/godot/combat/battlers/enemies/porcupine/StrongerPorcupineBattler.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://combat/battlers/Battler.tscn" type="PackedScene" id=1]
 [ext_resource path="res://combat/battlers/enemies/porcupine/PorcupineStronger.tres" type="Resource" id=2]
 [ext_resource path="res://animation/PorcupineAnim.tscn" type="PackedScene" id=3]
+[ext_resource path="res://combat/battlers/ai/RandomAI.gd" type="Script" id=4]
 
-[node name="StrongerPorcupine" index="0" instance=ExtResource( 1 )]
+[node name="StrongerPorcupine" instance=ExtResource( 1 )]
 stats = ExtResource( 2 )
 
 [node name="PorcupineAnim" parent="Skin" index="2" instance=ExtResource( 3 )]
+
+[node name="AI" parent="." index="6"]
+script = ExtResource( 4 )
 

--- a/godot/party/Party.tscn
+++ b/godot/party/Party.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://party/Party.gd" type="Script" id=1]
 [ext_resource path="res://party/PartyMember.tscn" type="PackedScene" id=2]
@@ -6,9 +6,10 @@
 [ext_resource path="res://animation/GodetteAnim.tscn" type="PackedScene" id=4]
 [ext_resource path="res://combat/battlers/skills/LearnedSkill.tscn" type="PackedScene" id=5]
 [ext_resource path="res://combat/battlers/skills/Lollislash.tres" type="Resource" id=6]
-[ext_resource path="res://combat/battlers/jobs/RobiJob.tres" type="Resource" id=7]
-[ext_resource path="res://animation/RobiAnim.tscn" type="PackedScene" id=8]
-[ext_resource path="res://combat/battlers/skills/Slash.tres" type="Resource" id=9]
+[ext_resource path="res://combat/battlers/ai/PlayerInput.gd" type="Script" id=7]
+[ext_resource path="res://combat/battlers/jobs/RobiJob.tres" type="Resource" id=8]
+[ext_resource path="res://animation/RobiAnim.tscn" type="PackedScene" id=9]
+[ext_resource path="res://combat/battlers/skills/Slash.tres" type="Resource" id=10]
 
 [node name="Party" type="Node2D"]
 script = ExtResource( 1 )
@@ -24,17 +25,23 @@ party_member = true
 [node name="LolliSlash" parent="Godette/Battler/Skills" index="0" instance=ExtResource( 5 )]
 skill = ExtResource( 6 )
 
+[node name="AI" parent="Godette/Battler" index="6"]
+script = ExtResource( 7 )
+
 [node name="Robi" parent="." instance=ExtResource( 2 )]
 
 [node name="Battler" parent="Robi" index="0"]
-stats = ExtResource( 7 )
+stats = ExtResource( 8 )
 party_member = true
 
-[node name="RobiAnim" parent="Robi/Battler/Skin" index="2" instance=ExtResource( 8 )]
+[node name="RobiAnim" parent="Robi/Battler/Skin" index="2" instance=ExtResource( 9 )]
 
 [node name="Slash" parent="Robi/Battler/Skills" index="0" instance=ExtResource( 5 )]
-skill = ExtResource( 9 )
+skill = ExtResource( 10 )
 level = 0
+
+[node name="AI" parent="Robi/Battler" index="6"]
+script = ExtResource( 7 )
 
 
 [editable path="Godette"]

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -14,6 +14,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://combat/battlers/Battler.gd"
 }, {
+"base": "Node",
+"class": "BattlerAI",
+"language": "GDScript",
+"path": "res://combat/battlers/ai/BattlerAI.gd"
+}, {
 "base": "Position2D",
 "class": "BattlerAnim",
 "language": "GDScript",
@@ -181,6 +186,7 @@ _global_script_classes=[ {
 } ]
 _global_script_class_icons={
 "Battler": "",
+"BattlerAI": "",
 "BattlerAnim": "",
 "BattlerTemplate": "",
 "CharacterStats": "",


### PR DESCRIPTION
Addresses #131 

AI has been broken into scripts and a generic node on Battlers.  You can override the AI node's script by assigning it a different script that `extends BattlerAI`.

Player Interface Input even has been moved into an AI script to keep the API as streamlined and generic as possible.  As such, the AI methods end up needing to have an async signature.  Until Godot's yield function supports safely awaiting on functions regardless of if they're async or not, an async stub such as yielding for an idle frame is necessary on fast executing AI.

Because the AI does all its own management and is a node on battlers, there's nothing stopping you from creating a complex AI script that relies on child nodes and constructs a behavior tree on a battler if so desired.

The sample random AI implementation, based on what was already coded onto battlers, is generic and supports being used on both players and enemies.  This means you can create party members who are not controlled by the player, which is a common approach used by RPGs for unimportant side characters or tutorial party members.