### PR TITLE
Manabars won't hide when depleted by default

### DIFF
--- a/godot/combat/interface/bars/StatBar.gd
+++ b/godot/combat/interface/bars/StatBar.gd
@@ -23,6 +23,8 @@ func set_value(new_value) -> void:
 	value = new_value
 	bar.value = new_value
 	label.display(new_value, max_value)
+	if HIDE_ON_DEPLETED and value == 0:
+		hide()
 
 func initialize(battler : Battler) -> void:
 	_connect_value_signals(battler)

--- a/godot/combat/interface/bars/manabar/HookableManaBar.tscn
+++ b/godot/combat/interface/bars/manabar/HookableManaBar.tscn
@@ -4,11 +4,13 @@
 [ext_resource path="res://combat/interface/bars/manabar/ManaBar.gd" type="Script" id=2]
 [ext_resource path="res://combat/interface/bars/manabar/fill.png" type="Texture" id=3]
 
-[node name="HookableManaBar" instance=ExtResource( 1 )]
+[node name="HookableManaBar" index="0" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
-LABEL_ABOVE = null
-HIDE_ON_DEPLETED = true
+HIDE_ON_DEPLETED = false
 
 [node name="TextureProgress" parent="Column" index="0"]
 texture_progress = ExtResource( 3 )
+
+[node name="LifeLabel" parent="Column" index="1"]
+margin_bottom = 52.0
 


### PR DESCRIPTION
Also, when a bar is set to hide when depleted, it will not show up again once another encounter starts.

Closes #133 