### PR TITLE
set initial animation for PawnAnim

### DIFF
--- a/godot/animation/PawnAnim.gd
+++ b/godot/animation/PawnAnim.gd
@@ -4,6 +4,9 @@ class_name PawnAnim
 
 onready var anim = $AnimationPlayer
 
+func _ready():
+	anim.set_current_animation('walk')
+
 func play_walk():
 	anim.play("walk")
 	yield(anim, "animation_finished")


### PR DESCRIPTION
This goes back to https://github.com/GDquest/godot-turn-based-rpg/issues/146 which was closed. There is still a odd jump when you first walk, which was due to `anim.get_current_animation_length()` getting 0 for the first step, and then 0.25 after that because an animation was set. This should fix it so it always gets the value on the first move.