### PR TITLE
Interaction only starts when clicking on top of InteractivePawns

### DIFF
--- a/godot/local_map/pawns/PawnInteractive.gd
+++ b/godot/local_map/pawns/PawnInteractive.gd
@@ -11,6 +11,8 @@ class_name PawnInteractive
 onready var raycasts : = $Raycasts as Node2D
 onready var dialogue_balloon : = $DialogueBalloon as Sprite
 
+const TOUCH_SAFE_MARGIN : int = 75
+
 export var vanish_on_interaction : = false
 export var AUTO_START_INTERACTION : = false
 export var sight_distance = 50
@@ -42,6 +44,8 @@ func _ready() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_accept") and dialogue_balloon.visible:
+		if (event is InputEventMouseButton or event is InputEventScreenTouch) and global_position.distance_to(get_global_mouse_position()) > TOUCH_SAFE_MARGIN:
+			return
 		start_interaction()
 		get_tree().set_input_as_handled()
 


### PR DESCRIPTION
Since left mouse click event is on `ui_accept`'s action list, this would trigger the interaction. I created a check to see if the mouse is close to the pawn when the event occurs. The distance can be tweaked to make it easier to click on top of the pawn if the game is running on a mobile device, for instance. Tested with both mouse and touch screen.

Closes #156