### PR TITLE
Quest rewards added

### DIFF
--- a/godot/Game.gd
+++ b/godot/Game.gd
@@ -21,6 +21,7 @@ var combat_arena : CombatArena
 func _ready():
 	local_map.visible = true
 	local_map.spawn_party(party)
+	quest_system.initialize(party)
 	local_map.quest_system = quest_system
 	$Debug/DebugInterface.initialize($GameSaver)
 

--- a/godot/Game.tscn
+++ b/godot/Game.tscn
@@ -26,7 +26,6 @@ editor/display_folded = true
 
 [node name="TransitionColor" parent="Overlays" instance=ExtResource( 5 )]
 mouse_filter = 2
-transition = 0.0
 
 [node name="GameOverInterface" parent="." instance=ExtResource( 6 )]
 layer = 0

--- a/godot/local_map/pawns/actions/DeliverQuestAction.gd
+++ b/godot/local_map/pawns/actions/DeliverQuestAction.gd
@@ -1,0 +1,14 @@
+extends MapAction
+class_name DeliverQuestAction
+
+export var quest : PackedScene
+
+func interact() -> void:
+	get_tree().paused = false
+	var quest_instance = quest.instance()
+	if local_map.quest_system.has_quest(quest_instance):
+		var finished_quest = local_map.quest_system.get_finished_quest(quest_instance)
+		if finished_quest != null:
+			finished_quest.deliver_quest()
+			local_map.quest_system.reward_player(finished_quest)
+	emit_signal("finished")

--- a/godot/local_map/pawns/actions/DeliverQuestAction.tscn
+++ b/godot/local_map/pawns/actions/DeliverQuestAction.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://local_map/pawns/actions/DeliverQuestAction.gd" type="Script" id=1]
+
+[node name="DeliverQuestAction" type="Node"]
+script = ExtResource( 1 )
+

--- a/godot/local_map/pawns/unique_pawns/QuestGiver.tscn
+++ b/godot/local_map/pawns/unique_pawns/QuestGiver.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://local_map/pawns/PawnInteractive.tscn" type="PackedScene" id=1]
 [ext_resource path="res://local_map/pawns/actions/DialogueAction.tscn" type="PackedScene" id=2]
 [ext_resource path="res://local_map/pawns/actions/GiveQuestAction.tscn" type="PackedScene" id=3]
 [ext_resource path="res://quest_system/quests/TestQuest.tscn" type="PackedScene" id=4]
+[ext_resource path="res://local_map/pawns/actions/DeliverQuestAction.tscn" type="PackedScene" id=5]
 
-[node name="QuestGiver" instance=ExtResource( 1 )]
+[node name="QuestGiver" index="0" instance=ExtResource( 1 )]
 facing = {
 "down": true,
 "left": true,
@@ -17,5 +18,8 @@ facing = {
 dialogue_file_path = "res://dialogue/data/quest_giver_conversation.json"
 
 [node name="GiveQuestAction" parent="Actions" index="1" instance=ExtResource( 3 )]
+quest = ExtResource( 4 )
+
+[node name="DeliverQuestAction" parent="Actions" index="2" instance=ExtResource( 5 )]
 quest = ExtResource( 4 )
 

--- a/godot/party/Inventory.gd
+++ b/godot/party/Inventory.gd
@@ -13,7 +13,7 @@ func add(item: Item, amount: int = 1) -> void:
 	if item in content:
 		content[item] += amount
 	else:
-		content[item] = 1 if item.is_unique else amount
+		content[item] = 1 if item.unique else amount
 
 func remove(item: Item, amount: int = 1):
 	assert item in content

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -55,6 +55,11 @@ _global_script_classes=[ {
 "path": "res://items/ConsumableItem.gd"
 }, {
 "base": "Node",
+"class": "DeliverQuestAction",
+"language": "GDScript",
+"path": "res://local_map/pawns/actions/DeliverQuestAction.gd"
+}, {
+"base": "Node",
 "class": "DialogueAction",
 "language": "GDScript",
 "path": "res://local_map/pawns/actions/DialogueAction.gd"
@@ -195,6 +200,11 @@ _global_script_classes=[ {
 "path": "res://quest_system/quests/QuestInteractObjective.gd"
 }, {
 "base": "Node",
+"class": "QuestItemReward",
+"language": "GDScript",
+"path": "res://quest_system/quests/QuestItemReward.gd"
+}, {
+"base": "Node",
 "class": "QuestObjective",
 "language": "GDScript",
 "path": "res://quest_system/QuestObjective.gd"
@@ -254,6 +264,7 @@ _global_script_class_icons={
 "CombatArena": "",
 "CombatPortrait": "",
 "ConsumableItem": "",
+"DeliverQuestAction": "",
 "DialogueAction": "",
 "DialogueBox": "",
 "DialoguePlayer": "",
@@ -282,6 +293,7 @@ _global_script_class_icons={
 "PawnLeader": "",
 "Quest": "",
 "QuestInteractObjective": "",
+"QuestItemReward": "",
 "QuestObjective": "",
 "QuestSlayObjective": "",
 "QuestSystem": "",

--- a/godot/quest_system/QuestSystem.gd
+++ b/godot/quest_system/QuestSystem.gd
@@ -1,7 +1,14 @@
 extends Node
 class_name QuestSystem
 
+signal quest_finished(quest)
+signal quest_delivered(quest)
+
 var quests = []
+var party : Party
+
+func initialize(party : Party ) -> void:
+	self.party = party
 
 func add_quest(new_quest) -> void:
 	add_child(new_quest)
@@ -9,7 +16,10 @@ func add_quest(new_quest) -> void:
 	new_quest.connect("quest_finished", self, "_on_quest_finished")
 
 func _on_quest_finished(quest) -> void:
-	print("Quest finished -> Give rewards")
+	emit_signal("quest_finished", quest)
+	if not quest.has_to_be_delivered:
+		quest.deliver_quest()
+		reward_player(quest)
 
 func _on_Game_combat_started() -> void:
 	for quest in quests:
@@ -20,3 +30,18 @@ func has_quest(other_quest) -> bool:
 		if quest.title == other_quest.title:
 			return true
 	return false
+
+func get_finished_quest(other_quest) -> Quest:
+	for quest in quests:
+		if quest.title == other_quest.title and quest.finished and quest.active:
+			return quest
+	return null
+
+func reward_player(quest) -> void:
+	emit_signal("quest_delivered", quest)
+	for item_reward in quest.item_rewards:
+		party.inventory.add(item_reward.item, item_reward.amount)
+
+	for party_member in party.get_active_members():
+		party_member.battler.stats.experience += quest.exp_reward
+		party_member.update_stats(party_member.battler.stats)

--- a/godot/quest_system/quests/Quest.gd
+++ b/godot/quest_system/quests/Quest.gd
@@ -5,15 +5,20 @@ signal quest_finished(quest)
 
 export var title : String
 export var description : String
+export var exp_reward : int
+export var has_to_be_delivered : bool = false
 
+var item_rewards = []
 var objectives = []
 var finished_objectives = []
 
 var active : bool = false
+var finished : bool = false
 
 func _ready() -> void:
 	active = true
-	for objective in get_children():
+	item_rewards = $ItemRewards.get_children()
+	for objective in $Objectives.get_children():
 		objectives.append(objective)
 		objective.connect("objective_finished", self, "_on_objective_finished")
 
@@ -21,10 +26,13 @@ func _on_objective_finished(objective) -> void:
 	finished_objectives.append(objective)
 	if finished_objectives.size() == objectives.size():
 		emit_signal("quest_finished", self)
-		active = false
+		finished = true
+
+func deliver_quest() -> void:
+	active = false
 
 func notify_slay_objectives() -> void:
-	for objective in get_children():
+	for objective in objectives:
 		if not objective is QuestSlayObjective:
 			continue
 		(objective as QuestSlayObjective).connect_signals()

--- a/godot/quest_system/quests/Quest.tscn
+++ b/godot/quest_system/quests/Quest.tscn
@@ -5,3 +5,7 @@
 [node name="Quest" type="Node"]
 script = ExtResource( 1 )
 
+[node name="ItemRewards" type="Node" parent="."]
+
+[node name="Objectives" type="Node" parent="."]
+

--- a/godot/quest_system/quests/QuestItemReward.gd
+++ b/godot/quest_system/quests/QuestItemReward.gd
@@ -1,0 +1,5 @@
+extends Node
+class_name QuestItemReward
+
+export var item : Resource
+export var amount : int

--- a/godot/quest_system/quests/QuestItemReward.tscn
+++ b/godot/quest_system/quests/QuestItemReward.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://quest_system/quests/QuestItemReward.gd" type="Script" id=1]
+
+[node name="QuestItemReward" type="Node"]
+script = ExtResource( 1 )
+

--- a/godot/quest_system/quests/TestQuest.tscn
+++ b/godot/quest_system/quests/TestQuest.tscn
@@ -1,19 +1,32 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://quest_system/quests/Quest.tscn" type="PackedScene" id=1]
-[ext_resource path="res://quest_system/quests/QuestSlayObjective.tscn" type="PackedScene" id=2]
-[ext_resource path="res://combat/battlers/enemies/porcupine/PorcupineBattler.tscn" type="PackedScene" id=3]
-[ext_resource path="res://quest_system/quests/QuestInteractObjective.tscn" type="PackedScene" id=4]
-[ext_resource path="res://local_map/pawns/unique_pawns/QuestDialogueTest.tscn" type="PackedScene" id=5]
+[ext_resource path="res://quest_system/quests/QuestItemReward.tscn" type="PackedScene" id=2]
+[ext_resource path="res://items/Potion.tres" type="Resource" id=3]
+[ext_resource path="res://items/Ether.tres" type="Resource" id=4]
+[ext_resource path="res://quest_system/quests/QuestSlayObjective.tscn" type="PackedScene" id=5]
+[ext_resource path="res://combat/battlers/enemies/porcupine/PorcupineBattler.tscn" type="PackedScene" id=6]
+[ext_resource path="res://quest_system/quests/QuestInteractObjective.tscn" type="PackedScene" id=7]
+[ext_resource path="res://local_map/pawns/unique_pawns/QuestDialogueTest.tscn" type="PackedScene" id=8]
 
 [node name="TestQuest" index="0" instance=ExtResource( 1 )]
 title = "Test Quest"
 description = "Just a quest for testing. Good luck!"
+exp_reward = 5
+has_to_be_delivered = false
 
-[node name="QuestSlayObjective" parent="." index="0" instance=ExtResource( 2 )]
+[node name="QuestItemReward" parent="ItemRewards" index="0" instance=ExtResource( 2 )]
+item = ExtResource( 3 )
+amount = 5
+
+[node name="QuestItemReward2" parent="ItemRewards" index="1" instance=ExtResource( 2 )]
+item = ExtResource( 4 )
+amount = 2
+
+[node name="QuestSlayObjective" parent="Objectives" index="0" instance=ExtResource( 5 )]
 amount = 3
-battler_to_slay = ExtResource( 3 )
+battler_to_slay = ExtResource( 6 )
 
-[node name="QuestInteractObjective" parent="." index="1" instance=ExtResource( 4 )]
-interact_with = ExtResource( 5 )
+[node name="QuestInteractObjective" parent="Objectives" index="1" instance=ExtResource( 7 )]
+interact_with = ExtResource( 8 )
 


### PR DESCRIPTION
### Rewards
Quests can now be configured to give players two types of rewards:
- Experience
- Items

The first is configured with an exported variable on the quest itself, the latter by adding instances of `QuestItemReward` on the Quest's `ItemRewards` node. 

### Deliveries
Before, quests would be completed and "delivered" (i.e. the player will get all the rewards from the quest) as soon as the objectives were completed. Now, this can be configured and they can either be delivered automatically or have to be delivered manually by the player by speaking to a NPC.

The delivery of the quest is done by a new `MapAction`: `DeliverQuestAction`. I opted to use this approach because we might want the quest to be delivered to a different NPC than the one which gave the quest in the first place.

### Conclusion
There is no notification to the player yet about the completion of quests. I figured it would be better to do this together with #152 
Also, as noted on #153 the dialogue with the NPC is still basic: the npc can't yet play a different dialogue in case the player delivered the quest and what not. 

Feedback would be appreciated @NathanLovato @nhydock 

Closes #151 

