### PR TITLE
Feat: select cells when moving

### DIFF
--- a/src/field/gamepieces/controllers/player_controller.gd
+++ b/src/field/gamepieces/controllers/player_controller.gd
@@ -126,6 +126,11 @@ func stop_moving() -> void:
 
 # The player has clicked on an empty gameboard cell. We'll try to move _gamepiece to the cell.
 func _on_cell_selected(cell: Vector2i) -> void:
+	# Wait until arrived when moving.
+	if is_active and _gamepiece.is_moving():
+		stop_moving()
+		await _gamepiece.arrived
+	
 	if is_active and not _gamepiece.is_moving():
 		var source_cell: = Gameboard.pixel_to_cell(_gamepiece.position)
 		


### PR DESCRIPTION
Allow player to interrupt moving by selecting cells. 

However, the player_cursor_marker will not changes its location until player_gamepieces move to a cell. So there will be a noticeable delay of player_cursor_marker if: 
- the speed of player_gamepieces is too slow.
- or the size of tiles is too big.

Closes #231 